### PR TITLE
add doc:tostr()

### DIFF
--- a/EzSVG.lua
+++ b/EzSVG.lua
@@ -847,7 +847,7 @@ function EzSVG.Document(width, height, bgcolor, style)
         }))
     end    
     
-    ret.writeTo = function(tbl, filename)
+    ret.tostr = function(tbl)
     
         local createRun = function(pre)
             return {
@@ -872,8 +872,12 @@ function EzSVG.Document(width, height, bgcolor, style)
             end
         end
         
+        return tbl:__generate(finalRun)
+    end
+
+    ret.writeTo = function(tbl, filename)
         local file = io.open(filename, "w")
-        file:write(tbl:__generate(finalRun))
+        file:write(tbl:tostr())
         io.close(file)
     end
     


### PR DESCRIPTION
doc:tostr() makes it possible to use the generated SVG as a string.
For example, dynamically generate SVG and send it to the client in a web server.